### PR TITLE
Allow importing of tsx files

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -1,12 +1,12 @@
 // Those two lines must be run before `require('lolex')` is first called
 const logProcessErrors = require('log-process-errors')
 logProcessErrors({
-  level: { 
+  level: {
     warning({ message }) {
       if (message.includes('queueMicrotask() is experimental')) {
-        return 'silent' 
+        return 'silent'
       }
-    } 
+    }
   }
 });
 
@@ -30,6 +30,7 @@ const { config } = cosmi;
 tsNode.register({
   transpileOnly: true,
   skipProject: true,
+  compilerOptions: { jsx: 'react' },
 });
 
 require('source-map-support/register');


### PR DESCRIPTION
While transitioning our angularjs codebase to React, we occasionally need to import values from tsx files into our legacy angular code. In order for `testify` to correctly resolve these imports, we need the following tweak to the tsconfig.